### PR TITLE
Fixes the encoder zip not available error when hitting the API

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -13,7 +13,7 @@ RUN  apk add curl \
      && ls -la /tmp/ \
      && cp -r /tmp/kegbot-server-${KEGBOT_VERSION}/* /app/ \
      && apk add gcc musl-dev \
-     && apk add libjpeg-turbo libjpeg-turbo-dev libjpeg openjpeg \
+     && apk add zlib-dev libjpeg-turbo libjpeg-turbo-dev libjpeg openjpeg \
      && apk add mysql-client \
      && apk add mariadb-dev \
      && ls -la ./ \


### PR DESCRIPTION
This error prevented the tablet app from properly syncing its tap status. The issue was that PIL (Pillow) uses zlib to handle data compression, which was missing from the Dockerfile.